### PR TITLE
Mark Vpuppr as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 
 {
-    "only-arches": ["x86_64"]
+    "only-arches": ["x86_64"],
+    "end-of-life": "This application is no longer supported, and the project source code repository was archived by its owner on May 30, 2024."
 } 


### PR DESCRIPTION
This application is no longer supported, and the project source code repository was archived by its owner on May 30, 2024.

See: https://github.com/virtual-puppet-project/vpuppr